### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # AutoJackson
 
-###Why AutoValue is awesome?
+### Why AutoValue is awesome?
 Just read [Google's explanation!](https://github.com/google/auto/tree/master/value)
 
 TLTR: It gives you immutability (thread safety!), `equals()`, `hashCode()` and `toString()` for free!
 
 ------
-###Okay, I'm in, show me the code!
+### Okay, I'm in, show me the code!
 
 Simple example of class annotated with [AutoValue](https://github.com/google/auto/tree/master/value) or [AutoParcel](https://github.com/frankiesardo/auto-parcel) + [Jackson](https://github.com/FasterXML/jackson).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
