### PR TITLE
Work with a very restricted object mapper

### DIFF
--- a/auto-jackson-example/src/main/java/com/artemzin/autojackson/Tweet.java
+++ b/auto-jackson-example/src/main/java/com/artemzin/autojackson/Tweet.java
@@ -1,17 +1,20 @@
 package com.artemzin.autojackson;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.auto.value.AutoValue;
 import org.jetbrains.annotations.NotNull;
 
 @AutoValue
-@JsonDeserialize(builder = AutoValue_Tweet.Builder.class)
+@JsonDeserialize(builder = Tweet.Builder.class)
+@JsonSerialize(as = Tweet.class)
 public abstract class Tweet {
 
   @NotNull
   public static Builder builder() {
-    return new AutoValue_Tweet.Builder();
+    return Builder.builder();
   }
 
   @NotNull
@@ -24,6 +27,10 @@ public abstract class Tweet {
 
   @AutoValue.Builder
   public static abstract class Builder {
+    @JsonCreator
+    public static Builder builder() {
+      return new AutoValue_Tweet.Builder();
+    }
     @NotNull
     @JsonProperty("author")
     public abstract Builder author(@NotNull String author);

--- a/auto-jackson-example/src/test/java/com/artemzin/autojacson/TweetTest.java
+++ b/auto-jackson-example/src/test/java/com/artemzin/autojacson/TweetTest.java
@@ -2,6 +2,7 @@ package com.artemzin.autojacson;
 
 import com.artemzin.autojackson.Tweet;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
@@ -14,7 +15,7 @@ public class TweetTest {
 
   @Test
   public void shouldSerializeToJson() throws JsonProcessingException {
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = getObjectMapper();
 
     Tweet tweet = Tweet.builder()
       .author("@artem_zin")
@@ -27,7 +28,7 @@ public class TweetTest {
 
   @Test
   public void shouldDeserializeFromJson() throws IOException {
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = getObjectMapper();
 
     String json = "{\"author\":\"@artem_zin\",\"content\":\"Immutability for everybody!\"}";
 
@@ -35,5 +36,19 @@ public class TweetTest {
 
     assertThat(tweet.author()).isEqualTo("@artem_zin");
     assertThat(tweet.content()).isEqualTo("Immutability for everybody!");
+  }
+
+  private ObjectMapper getObjectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.disable(MapperFeature.AUTO_DETECT_CREATORS);
+    objectMapper.disable(MapperFeature.AUTO_DETECT_FIELDS);
+    objectMapper.disable(MapperFeature.AUTO_DETECT_SETTERS);
+    objectMapper.disable(MapperFeature.AUTO_DETECT_GETTERS);
+    objectMapper.disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
+    objectMapper.disable(MapperFeature.USE_GETTERS_AS_SETTERS);
+    objectMapper.disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS);
+    objectMapper.disable(MapperFeature.INFER_PROPERTY_MUTATORS);
+    objectMapper.disable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS);
+    return objectMapper;
   }
 }


### PR DESCRIPTION
The sample code relied on a number of internal features of Jackson
that are turned on by default. If those are turned off (e.g. if there
is no control over the object mapper that is used), the sample code
actually does not work.

This tweaks the demo code a bit so that even with a very restricted
object mapper, the sample code still works.