### PR TITLE
Simplify the annotations needed for jackson

### DIFF
--- a/auto-jackson-example/src/main/java/com/artemzin/autojackson/Tweet.java
+++ b/auto-jackson-example/src/main/java/com/artemzin/autojackson/Tweet.java
@@ -1,42 +1,33 @@
 package com.artemzin.autojackson;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.auto.value.AutoValue;
 import org.jetbrains.annotations.NotNull;
 
 @AutoValue
-@JsonDeserialize(builder = Tweet.Builder.class)
-@JsonSerialize(as = Tweet.class)
+@JsonDeserialize(builder = AutoValue_Tweet.Builder.class)
 public abstract class Tweet {
 
   @NotNull
   public static Builder builder() {
-    return Builder.builder();
+    return new AutoValue_Tweet.Builder();
   }
 
   @NotNull
-  @JsonProperty("author")
   public abstract String author();
 
   @NotNull
-  @JsonProperty("content")
   public abstract String content();
 
   @AutoValue.Builder
+  @JsonPOJOBuilder(withPrefix = "set")
   public static abstract class Builder {
-    @JsonCreator
-    public static Builder builder() {
-      return new AutoValue_Tweet.Builder();
-    }
     @NotNull
-    @JsonProperty("author")
     public abstract Builder author(@NotNull String author);
 
     @NotNull
-    @JsonProperty("content")
     public abstract Builder content(@NotNull String content);
 
     @NotNull


### PR DESCRIPTION
* @JsonPOJOBuilder(withPrefix = "set") replaced the need for @JsonProperty on the Builder
* @JsonDeserialize(builder = AutoValue_Tweet.Builder.class) instead of @JsonDeserialize(builder = Tweet.Builder.class) removes the need for the @JsonCreator
* The @JsonSerialize is implicit in this case and can be omitted
* The @JsonProperty on the getters is implicit and can be omitted